### PR TITLE
make compatible to windows cmdline cmake 3.17.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,18 +32,33 @@ if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
 endif()
 
 
-add_library(
-	libbliss
-	src/bliss_C.cc
-	src/defs.cc
-	src/graph.cc
-	src/heap.cc
-	src/orbit.cc
-	src/partition.cc
-	src/timer.cc
-	src/uintseqhash.cc
-	src/utils.cc
-)
+if(WIN32)
+  add_library(
+    libbliss
+    src/bliss_C.cc
+    src/defs.cc
+    src/graph.cc
+    src/heap.cc
+    src/orbit.cc
+    src/partition.cc
+    src/uintseqhash.cc
+    src/utils.cc
+  )
+else()
+  add_library(
+    libbliss
+    src/bliss_C.cc
+    src/defs.cc
+    src/graph.cc
+    src/heap.cc
+    src/orbit.cc
+    src/partition.cc
+    src/timer.cc
+    src/uintseqhash.cc
+    src/utils.cc
+  )
+endif()
+
 set_target_properties(libbliss PROPERTIES OUTPUT_NAME bliss)
 add_library(Bliss::libbliss ALIAS libbliss)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,14 +3,14 @@ cmake_minimum_required(VERSION 3.10)
 if(${CMAKE_VERSION} VERSION_LESS "3.12")
   project(
     Bliss
-    VERSION 0.73.1
+    VERSION 0.73.3
     LANGUAGES CXX C
     DESCRIPTION "A Tool for Computing Automorphism Groups and Canonical Labelings of Graphs. http://www.tcs.hut.fi/Software/bliss/."
   )
 else()
   project(
     Bliss
-    VERSION 0.73.1
+    VERSION 0.73.3
     LANGUAGES CXX C
     DESCRIPTION "A Tool for Computing Automorphism Groups and Canonical Labelings of Graphs"
     HOMEPAGE_URL "http://www.tcs.hut.fi/Software/bliss/"

--- a/include/bliss/defs.hh
+++ b/include/bliss/defs.hh
@@ -7,9 +7,9 @@
 /*
   Copyright (c) 2003-2015 Tommi Junttila
   Released under the GNU Lesser General Public License version 3.
-  
+
   This file is part of bliss.
-  
+
   bliss is free software: you can redistribute it and/or modify
   it under the terms of the GNU Lesser General Public License as published by
   the Free Software Foundation, version 3 of the License.
@@ -28,7 +28,7 @@ namespace bliss {
 /**
  * The version number of bliss.
  */
-static const char * const version = "0.73";
+static const char * const version = "0.73.3";
 
 /*
  * If a fatal error (out of memory, internal error) is encountered,

--- a/src/bliss.cc
+++ b/src/bliss.cc
@@ -8,7 +8,7 @@
 
 #include "bliss/defs.hh"
 #include "bliss/graph.hh"
-#ifdef _WIN32
+#ifndef _WIN32
   #include "bliss/timer.hh"
 #endif
 #include "bliss/utils.hh"
@@ -189,7 +189,7 @@ _fatal(const char* fmt, ...)
 int
 main(const int argc, const char** argv)
 {
-#ifdef _WIN32
+#ifndef _WIN32
   bliss::Timer timer;
 #endif
   bliss::AbstractGraph* g = 0;
@@ -261,7 +261,7 @@ main(const int argc, const char** argv)
   if(!g)
     _fatal("Failed to read the graph, aborting");
 
-#ifdef _WIN32
+#ifndef _WIN32
   if(verbose_level >= 2)
     {
       fprintf(verbstr, "Graph read in %.2f seconds\n", timer.get_duration());
@@ -313,7 +313,7 @@ main(const int argc, const char** argv)
   if(verbose_level > 0 and verbstr)
     stats.print(verbstr);
 
-#ifdef _WIN32
+#ifndef _WIN32
   if(verbose_level > 0)
     {
       fprintf(verbstr, "Total time:\t%.2f seconds\n", timer.get_duration());

--- a/src/bliss.cc
+++ b/src/bliss.cc
@@ -2,17 +2,23 @@
 #include <cstdio>
 #include <cstring>
 #include <cassert>
+#ifdef _WIN32
+  #include <ciso646>
+#endif
+
 #include "bliss/defs.hh"
 #include "bliss/graph.hh"
-#include "bliss/timer.hh"
+#ifdef _WIN32
+  #include "bliss/timer.hh"
+#endif
 #include "bliss/utils.hh"
 
 /*
   Copyright (c) 2003-2015 Tommi Junttila
   Released under the GNU Lesser General Public License version 3.
-  
+
   This file is part of bliss.
-  
+
   bliss is free software: you can redistribute it and/or modify
   it under the terms of the GNU Lesser General Public License as published by
   the Free Software Foundation, version 3 of the License.
@@ -52,11 +58,11 @@ static void
 usage(FILE* const fp, const char* argv0)
 {
   const char* program_name;
-  
-  program_name = rindex(argv0, '/');
-  
+
+  program_name = strrchr(argv0, '/');
+
   if(program_name) program_name++;
-  else program_name = argv0;  
+  else program_name = argv0;
   if(!program_name or *program_name == 0) program_name = "bliss";
 
   fprintf(fp, "bliss version %s (compiled %s)\n", bliss::version, __DATE__);
@@ -183,11 +189,13 @@ _fatal(const char* fmt, ...)
 int
 main(const int argc, const char** argv)
 {
+#ifdef _WIN32
   bliss::Timer timer;
+#endif
   bliss::AbstractGraph* g = 0;
 
   parse_options(argc, argv);
-  
+
   /* Parse splitting heuristics */
   bliss::Digraph::SplittingHeuristic shs_directed = bliss::Digraph::shs_fsm;
   bliss::Graph::SplittingHeuristic shs_undirected = bliss::Graph::shs_fsm;
@@ -246,18 +254,20 @@ main(const int argc, const char** argv)
       /* Read undirected graph in the DIMACS format */
       g = bliss::Graph::read_dimacs(infile);
     }
-  
+
   if(infile != stdin)
     fclose(infile);
 
   if(!g)
     _fatal("Failed to read the graph, aborting");
-  
+
+#ifdef _WIN32
   if(verbose_level >= 2)
     {
       fprintf(verbstr, "Graph read in %.2f seconds\n", timer.get_duration());
       fflush(verbstr);
     }
+#endif
 
 
   bliss::Stats stats;
@@ -303,12 +313,13 @@ main(const int argc, const char** argv)
   if(verbose_level > 0 and verbstr)
     stats.print(verbstr);
 
+#ifdef _WIN32
   if(verbose_level > 0)
     {
       fprintf(verbstr, "Total time:\t%.2f seconds\n", timer.get_duration());
       fflush(verbstr);
     }
-
+#endif
 
   delete g; g = 0;
 

--- a/src/graph.cc
+++ b/src/graph.cc
@@ -9,7 +9,7 @@
 #endif
 
 #include "bliss/defs.hh"
-#ifdef _WIN32
+#ifndef _WIN32
   #include "bliss/timer.hh"
 #endif
 #include "bliss/graph.hh"
@@ -679,13 +679,13 @@ AbstractGraph::search(const bool canonical, Stats& stats)
    * This saves some cycles. */
   compute_eqref_hash = false;
 
-#ifdef _WIN32
+#ifndef _WIN32
   Timer timer1;
 #endif
 
   make_initial_equitable_partition();
 
-#ifdef _WIN32
+#ifndef _WIN32
   if(verbstr and verbose_level >= 2)
     {
       fprintf(verbstr, "Initial partition computed in %.2f seconds\n",

--- a/src/graph.cc
+++ b/src/graph.cc
@@ -4,9 +4,14 @@
 #include <set>
 #include <list>
 #include <algorithm>
+#ifdef _WIN32
+  #include <ciso646>
+#endif
 
 #include "bliss/defs.hh"
-#include "bliss/timer.hh"
+#ifdef _WIN32
+  #include "bliss/timer.hh"
+#endif
 #include "bliss/graph.hh"
 #include "bliss/partition.hh"
 #include "bliss/utils.hh"
@@ -14,9 +19,9 @@
 /*
   Copyright (c) 2003-2015 Tommi Junttila
   Released under the GNU Lesser General Public License version 3.
-  
+
   This file is part of bliss.
-  
+
   bliss is free software: you can redistribute it and/or modify
   it under the terms of the GNU Lesser General Public License as published by
   the Free Software Foundation, version 3 of the License.
@@ -87,7 +92,7 @@ AbstractGraph::~AbstractGraph()
     free(first_path_automorphism); first_path_automorphism = 0; }
   if(best_path_automorphism) {
     free(best_path_automorphism); best_path_automorphism = 0; }
- 
+
   report_hook = 0;
   report_user_param = 0;
 }
@@ -605,7 +610,7 @@ public:
   bool needs_long_prune;
   unsigned int long_prune_begin;
   std::set<unsigned int, std::less<unsigned int> > long_prune_redundant;
-  
+
   UintSeqHash eqref_hash;
   unsigned int subcertificate_length;
 };
@@ -663,7 +668,7 @@ AbstractGraph::search(const bool canonical, Stats& stats)
   /* ... and the component recursion data structures in the partition */
   if(opt_use_comprec)
     p.cr_init();
-  
+
   neighbour_heap.init(N);
 
   in_search = false;
@@ -674,19 +679,20 @@ AbstractGraph::search(const bool canonical, Stats& stats)
    * This saves some cycles. */
   compute_eqref_hash = false;
 
+#ifdef _WIN32
   Timer timer1;
+#endif
 
   make_initial_equitable_partition();
 
-
+#ifdef _WIN32
   if(verbstr and verbose_level >= 2)
     {
       fprintf(verbstr, "Initial partition computed in %.2f seconds\n",
 	      timer1.get_duration());
       fflush(verbstr);
     }
-  
-
+#endif
 
   /*
    * Allocate space for the "first path" and "best path" labelings
@@ -777,7 +783,7 @@ AbstractGraph::search(const bool canonical, Stats& stats)
   cr_level = 0;
   if(opt_use_comprec and
      nucr_find_first_component(cr_level) == true and
-     p.nof_discrete_cells() + cr_component_elements < 
+     p.nof_discrete_cells() + cr_component_elements <
      cr_cep_stack[cr_cep_index].discrete_cell_limit)
     {
       cr_level = p.cr_split_level(0, cr_component);
@@ -831,7 +837,7 @@ AbstractGraph::search(const bool canonical, Stats& stats)
   /*
    * The actual backtracking search
    */
-  while(!search_stack.empty()) 
+  while(!search_stack.empty())
     {
       TreeNode&          current_node  = search_stack.back();
       const unsigned int current_level = (unsigned int)search_stack.size()-1;
@@ -861,7 +867,7 @@ AbstractGraph::search(const bool canonical, Stats& stats)
 	  if(current_node.fp_extendable == TreeNode::YES)
 	    {
 	      search_stack.pop_back();
-	      continue;	      
+	      continue;
 	    }
 	  if(current_node.split_element == TreeNode::SPLIT_END)
 	    {
@@ -901,7 +907,7 @@ AbstractGraph::search(const bool canonical, Stats& stats)
       /* Fetch split cell information */
       Partition::Cell * const cell =
 	p.get_cell(p.elements[current_node.split_cell_first]);
-  
+
       /* Restore component recursion information */
       cr_level = current_node.cr_level;
       cr_cep_stack.resize(current_node.cr_cep_stack_size);
@@ -1043,7 +1049,7 @@ AbstractGraph::search(const bool canonical, Stats& stats)
 	      }
 	    continue;
 	  }
-	
+
 	/* Split on smallest */
 	current_node.split_element = next_split_element;
       }
@@ -1090,7 +1096,7 @@ AbstractGraph::search(const bool canonical, Stats& stats)
        */
       if(cell->is_unit())
 	refine_to_equitable(cell, new_cell);
-      else 
+      else
 	refine_to_equitable(new_cell);
 
 
@@ -1104,7 +1110,7 @@ AbstractGraph::search(const bool canonical, Stats& stats)
       if(!first_path_info.empty())
 	{
 	  /* We are no longer on the first path */
-	  const unsigned int subcertificate_length = 
+	  const unsigned int subcertificate_length =
 	    certificate_current_path.size() - certificate_index;
 	  if(refine_equal_to_first)
 	    {
@@ -1175,7 +1181,7 @@ AbstractGraph::search(const bool canonical, Stats& stats)
 		}
 	    }
 
-	  
+
 	  /* Check if no longer equal to the first path and,
 	   * if canonical labeling is desired, also worse than the
 	   * current best path */
@@ -1301,14 +1307,14 @@ AbstractGraph::search(const bool canonical, Stats& stats)
 
 	  if(opt_use_failure_recording)
 	    failure_recording_hashes.resize(base_size);
-	  
+
 	  /*
 	  for(unsigned int j = 0; j < search_stack.size(); j++)
 	    fprintf(stderr, "%u ", search_stack[j].split_element);
 	  fprintf(stderr, "\n");
 	  p.print(stderr); fprintf(stderr, "\n");
 	  */
-	  
+
 	  /*
 	   * Backtrack to the previous level
 	   */
@@ -1558,7 +1564,7 @@ AbstractGraph::search(const bool canonical, Stats& stats)
 	  continue;
 	}
 
-      
+
     handle_best_path_automorphism:
       /*
        *
@@ -1592,13 +1598,13 @@ AbstractGraph::search(const bool canonical, Stats& stats)
 		  best_path_automorphism[p.elements[i]] = p.elements[i];
 	    }
 	  }
-	
+
 #if defined(BLISS_VERIFY_AUTOMORPHISMS)
 	/* Verify that it really is an automorphism */
 	if(!is_automorphism(best_path_automorphism))
 	  fatal_error("Best path automorhism validation check failed");
 #endif
-	
+
 	unsigned int gca_level_with_first = 0;
 	for(unsigned int i = search_stack.size(); i > 0; i--) {
 	  if((int)first_path_info[gca_level_with_first].splitting_element !=
@@ -1620,7 +1626,7 @@ AbstractGraph::search(const bool canonical, Stats& stats)
 	    /* Record automorphism */
 	    long_prune_add_automorphism(best_path_automorphism);
 	  }
-	    
+
 	/*
 	 * Update orbit information
 	 */
@@ -1644,7 +1650,7 @@ AbstractGraph::search(const bool canonical, Stats& stats)
        if (limit_generators && stats.nof_generators >= limit_generators)
           break;
 	  }
-	  
+
 	/*
 	 * Compute backjumping level
 	 */
@@ -1666,14 +1672,14 @@ AbstractGraph::search(const bool canonical, Stats& stats)
 
       _INTERNAL_ERROR();
 
-      
+
     handle_first_path_automorphism:
       /*
        *
        * A first-path automorphism: aut[i] = elements[first_path_labeling[i]]
        *
        */
-      
+
 
       if(p.is_discrete())
 	{
@@ -1703,17 +1709,17 @@ AbstractGraph::search(const bool canonical, Stats& stats)
       if(!is_automorphism(first_path_automorphism))
 	fatal_error("First path automorphism validation check failed");
 #endif
-      
+
       if(opt_use_long_prune)
 	{
 	  long_prune_add_automorphism(first_path_automorphism);
 	}
-      
+
       /*
        * Update orbit information
        */
       update_orbit_information(first_path_orbits, first_path_automorphism);
-      
+
       /*
        * Compute backjumping level
        */
@@ -2198,7 +2204,7 @@ Digraph::read_dimacs(FILE* const fp, FILE* const errstr)
 
   const bool verbose = false;
   FILE* const verbstr = stdout;
-  
+
   /* Read comments and the problem definition line */
   while(1)
     {
@@ -2235,7 +2241,7 @@ Digraph::read_dimacs(FILE* const fp, FILE* const errstr)
 	fprintf(errstr, "error in line %u: not in DIMACS format\n", line_num);
       goto error_exit;
     }
-  
+
   if(nof_vertices <= 0)
     {
       if(errstr)
@@ -2336,7 +2342,7 @@ Digraph::read_dimacs(FILE* const fp, FILE* const errstr)
       fprintf(verbstr, "Done\n");
       fflush(verbstr);
     }
-  
+
   return g;
 
  error_exit:
@@ -2455,7 +2461,7 @@ Digraph::refine_according_to_invariant(unsigned int (*inv)(const Digraph* const 
 
   for(Partition::Cell* cell = p.first_nonsingleton_cell; cell; )
     {
-      
+
       Partition::Cell* const next_cell = cell->next_nonsingleton;
       const unsigned int* ep = p.elements + cell->first;
       for(unsigned int i = cell->length; i > 0; i--, ep++)
@@ -2491,7 +2497,7 @@ Digraph::refine_according_to_invariant(unsigned int (*inv)(const Digraph* const 
 bool
 Digraph::split_neighbourhood_of_cell(Partition::Cell* const cell)
 {
-  
+
 
   const bool was_equal_to_first = refine_equal_to_first;
 
@@ -2505,7 +2511,7 @@ Digraph::split_neighbourhood_of_cell(Partition::Cell* const cell)
   for(unsigned int i = cell->length; i > 0; i--)
     {
       const Vertex& v = vertices[*ep++];
-      
+
       std::vector<unsigned int>::const_iterator ei = v.edges_out.begin();
       for(unsigned int j = v.nof_edges_out(); j != 0; j--)
 	{
@@ -2530,7 +2536,7 @@ Digraph::split_neighbourhood_of_cell(Partition::Cell* const cell)
     {
       const unsigned int start = neighbour_heap.remove();
       Partition::Cell* const neighbour_cell = p.get_cell(p.elements[start]);
-      
+
       if(compute_eqref_hash)
 	{
 	  eqref_hash.update(neighbour_cell->first);
@@ -2646,7 +2652,7 @@ Digraph::split_neighbourhood_of_cell(Partition::Cell* const cell)
     return true;
 
   return false;
-  
+
  worse_exit:
   /* Clear neighbour heap */
   UintSeqHash rest;
@@ -2707,7 +2713,7 @@ Digraph::split_neighbourhood_of_unit_cell(Partition::Cell* const unit_cell)
     {
       const unsigned int dest_vertex = *ei++;
       Partition::Cell* const neighbour_cell = p.get_cell(dest_vertex);
-   
+
       if(neighbour_cell->is_unit()) {
 	if(in_search) {
 	  /* Remember neighbour in order to generate certificate */
@@ -2720,7 +2726,7 @@ Digraph::split_neighbourhood_of_unit_cell(Partition::Cell* const unit_cell)
 	  neighbour_heap.insert(neighbour_cell->first);
 	}
       neighbour_cell->max_ival_count++;
-      
+
       unsigned int* const swap_position =
 	p.elements + neighbour_cell->first + neighbour_cell->length -
 	neighbour_cell->max_ival_count;
@@ -2755,7 +2761,7 @@ Digraph::split_neighbourhood_of_unit_cell(Partition::Cell* const unit_cell)
       if(neighbour_cell->length > 1 and
 	 neighbour_cell->max_ival_count != neighbour_cell->length)
 	{
-	  
+
 	  Partition::Cell* const new_cell =
 	    p.aux_split_in_two(neighbour_cell,
 			       neighbour_cell->length -
@@ -2769,7 +2775,7 @@ Digraph::split_neighbourhood_of_unit_cell(Partition::Cell* const unit_cell)
 	    }
 	  neighbour_cell->max_ival_count = 0;
 
-	  
+
 	  if(compute_eqref_hash)
 	    {
 	      /* Update hash */
@@ -2780,7 +2786,7 @@ Digraph::split_neighbourhood_of_unit_cell(Partition::Cell* const unit_cell)
 	      eqref_hash.update(new_cell->length);
 	      eqref_hash.update(1);
 	    }
-	  
+
 	  /* Add cells in splitting_queue */
 	  if(neighbour_cell->is_in_splitting_queue()) {
 	    /* Both cells must be included in splitting_queue in order
@@ -2809,7 +2815,7 @@ Digraph::split_neighbourhood_of_unit_cell(Partition::Cell* const unit_cell)
 	{
 	  neighbour_cell->max_ival_count = 0;
 	}
-      
+
       /*
        * Build certificate if required
        */
@@ -2840,7 +2846,7 @@ Digraph::split_neighbourhood_of_unit_cell(Partition::Cell* const unit_cell)
     {
       const unsigned int dest_vertex = *ei++;
       Partition::Cell* const neighbour_cell = p.get_cell(dest_vertex);
-      
+
       if(neighbour_cell->is_unit()) {
 	if(in_search) {
 	  neighbour_heap.insert(neighbour_cell->first);
@@ -2898,8 +2904,8 @@ Digraph::split_neighbourhood_of_unit_cell(Partition::Cell* const unit_cell)
 	    ep++;
 	  }
 	  neighbour_cell->max_ival_count = 0;
-	  
-	  
+
+
 	  if(compute_eqref_hash)
 	    {
 	      eqref_hash.update(neighbour_cell->first);
@@ -2938,7 +2944,7 @@ Digraph::split_neighbourhood_of_unit_cell(Partition::Cell* const unit_cell)
 	{
 	  neighbour_cell->max_ival_count = 0;
 	}
-      
+
       /*
        * Build certificate if required
        */
@@ -3298,7 +3304,7 @@ Digraph::sh_first_max_neighbours()
 	    value++;
 	  neighbour_cell->max_ival = 0;
 	}
-      
+
       if(value > best_value)
 	{
 	  best_value = value;
@@ -3327,10 +3333,10 @@ Digraph::sh_first_smallest_max_neighbours()
       cell;
       cell = cell->next_nonsingleton)
     {
-	
+
       if(opt_use_comprec and p.cr_get_level(cell->first) != cr_level)
 	continue;
-	
+
       int value = 0;
       const Vertex& v = vertices[p.elements[cell->first]];
       std::vector<unsigned int>::const_iterator ei;
@@ -3595,7 +3601,7 @@ Digraph::nucr_find_first_component(const unsigned int level)
   /* The component is discrete, return false */
   if(!first_cell)
     return false;
-	
+
   std::vector<Partition::Cell*> component;
   first_cell->max_ival = 1;
   component.push_back(first_cell);
@@ -3603,7 +3609,7 @@ Digraph::nucr_find_first_component(const unsigned int level)
   for(unsigned int i = 0; i < component.size(); i++)
     {
       Partition::Cell* const cell = component[i];
-	  
+
       const Vertex& v = vertices[p.elements[cell->first]];
       std::vector<unsigned int>::const_iterator ei;
 
@@ -3632,13 +3638,13 @@ Digraph::nucr_find_first_component(const unsigned int level)
 	  const unsigned int start = neighbour_heap.remove();
 	  Partition::Cell* const neighbour_cell =
 	    p.get_cell(p.elements[start]);
-	  
+
 	  /* Skip saturated neighbour cells */
 	  if(neighbour_cell->max_ival_count == neighbour_cell->length)
 	    {
 	      neighbour_cell->max_ival_count = 0;
 	      continue;
-	    } 
+	    }
 	  neighbour_cell->max_ival_count = 0;
 	  neighbour_cell->max_ival = 1;
 	  component.push_back(neighbour_cell);
@@ -3648,7 +3654,7 @@ Digraph::nucr_find_first_component(const unsigned int level)
       for(unsigned int j = v.nof_edges_in(); j > 0; j--)
 	{
 	  const unsigned int neighbour = *ei++;
-	  
+
 	  Partition::Cell* const neighbour_cell = p.get_cell(neighbour);
 
 	  /* Skip unit neighbours */
@@ -3670,13 +3676,13 @@ Digraph::nucr_find_first_component(const unsigned int level)
 	  const unsigned int start = neighbour_heap.remove();
 	  Partition::Cell* const neighbour_cell =
 	    p.get_cell(p.elements[start]);
-	  
+
 	  /* Skip saturated neighbour cells */
 	  if(neighbour_cell->max_ival_count == neighbour_cell->length)
 	    {
 	      neighbour_cell->max_ival_count = 0;
 	      continue;
-	    } 
+	    }
 	  neighbour_cell->max_ival_count = 0;
 	  neighbour_cell->max_ival = 1;
 	  component.push_back(neighbour_cell);
@@ -3732,7 +3738,7 @@ Digraph::nucr_find_first_component(const unsigned int level,
       /* The component is discrete, return false */
       return false;
     }
-	
+
   std::vector<Partition::Cell*> comp;
   KStack<Partition::Cell*> neighbours;
   neighbours.init(get_nof_vertices());
@@ -3754,7 +3760,7 @@ Digraph::nucr_find_first_component(const unsigned int level,
       for(unsigned int j = v.nof_edges_out(); j > 0; j--)
 	{
 	  const unsigned int neighbour = *ei++;
-	  
+
 	  Partition::Cell* const neighbour_cell = p.get_cell(neighbour);
 
 	  /* Skip unit neighbours */
@@ -4048,7 +4054,7 @@ Graph::read_dimacs(FILE* const fp, FILE* const errstr)
 
   const bool verbose = false;
   FILE* const verbstr = stdout;
-  
+
   /* Read comments and the problem definition line */
   while(1)
     {
@@ -4087,7 +4093,7 @@ Graph::read_dimacs(FILE* const fp, FILE* const errstr)
 	fprintf(errstr, "error in line %u: not in DIMACS format\n", line_num);
       goto error_exit;
     }
-  
+
   if(nof_vertices <= 0)
     {
       if(errstr)
@@ -4606,7 +4612,7 @@ Graph::split_neighbourhood_of_cell(Partition::Cell* const cell)
   for(unsigned int i = cell->length; i > 0; i--)
     {
       const Vertex& v = vertices[*ep++];
-      
+
       std::vector<unsigned int>::const_iterator ei = v.edges.begin();
       for(unsigned int j = v.nof_edges(); j != 0; j--)
 	{
@@ -4628,12 +4634,12 @@ Graph::split_neighbourhood_of_cell(Partition::Cell* const cell)
 	  }
 	}
     }
-  
+
   while(!neighbour_heap.is_empty())
     {
       const unsigned int start = neighbour_heap.remove();
       Partition::Cell * const neighbour_cell = p.get_cell(p.elements[start]);
-      
+
       if(compute_eqref_hash)
 	{
 	  eqref_hash.update(neighbour_cell->first);
@@ -4707,7 +4713,7 @@ Graph::split_neighbourhood_of_cell(Partition::Cell* const cell)
       rest.update(failure_recording_fp_deviation);
       failure_recording_fp_deviation = rest.get_value();
     }
- 
+
   return true;
 }
 
@@ -4734,7 +4740,7 @@ Graph::split_neighbourhood_of_unit_cell(Partition::Cell* const unit_cell)
     {
       const unsigned int dest_vertex = *ei++;
       Partition::Cell * const neighbour_cell = p.get_cell(dest_vertex);
-      
+
       if(neighbour_cell->is_unit()) {
 	if(in_search) {
 	  /* Remember neighbour in order to generate certificate */
@@ -4756,7 +4762,7 @@ Graph::split_neighbourhood_of_unit_cell(Partition::Cell* const unit_cell)
       *swap_position = dest_vertex;
       p.in_pos[dest_vertex] = swap_position;
     }
-  
+
   while(!neighbour_heap.is_empty())
     {
       const unsigned int start = neighbour_heap.remove();
@@ -4790,8 +4796,8 @@ Graph::split_neighbourhood_of_unit_cell(Partition::Cell* const unit_cell)
 	      ep++;
 	    }
 	  neighbour_cell->max_ival_count = 0;
-	  
-	  
+
+
 	  if(compute_eqref_hash)
 	    {
 	      /* Update hash */
@@ -4802,7 +4808,7 @@ Graph::split_neighbourhood_of_unit_cell(Partition::Cell* const unit_cell)
 	      eqref_hash.update(new_cell->length);
 	      eqref_hash.update(1);
 	    }
-	  
+
 	  /* Add cells in splitting_queue */
 	  if(neighbour_cell->is_in_splitting_queue()) {
 	    /* Both cells must be included in splitting_queue in order
@@ -4833,7 +4839,7 @@ Graph::split_neighbourhood_of_unit_cell(Partition::Cell* const unit_cell)
 	     neighbour_cell->max_ival_count == neighbour_cell->length */
 	  neighbour_cell->max_ival_count = 0;
 	}
-      
+
       /*
        * Build certificate if required
        */
@@ -4854,7 +4860,7 @@ Graph::split_neighbourhood_of_unit_cell(Partition::Cell* const unit_cell)
 	    }
 	} /* if(in_search) */
     } /* while(!neighbour_heap.is_empty()) */
-  
+
   if(refine_compare_certificate and
      (refine_equal_to_first == false) and
      (refine_cmp_to_best < 0))
@@ -4913,7 +4919,7 @@ bool Graph::is_equitable() const
     {
       if(cell->is_unit())
 	continue;
-      
+
       unsigned int *ep = p.elements + cell->first;
       const Vertex &first_vertex = vertices[*ep++];
 
@@ -5153,7 +5159,7 @@ Graph::sh_first_smallest_max_neighbours()
 
       if(opt_use_comprec and p.cr_get_level(cell->first) != cr_level)
 	continue;
-	
+
       const Vertex& v = vertices[p.elements[cell->first]];
       std::vector<unsigned int>::const_iterator ei = v.edges.begin();
       for(unsigned int j = v.nof_edges(); j > 0; j--)
@@ -5300,7 +5306,7 @@ Graph::is_automorphism(unsigned int* const perm)
 	  ei != v1.edges.end();
 	  ei++)
 	edges1.insert(perm[*ei]);
-      
+
       Vertex& v2 = vertices[perm[i]];
       edges2.clear();
       for(std::vector<unsigned int>::iterator ei = v2.edges.begin();
@@ -5336,7 +5342,7 @@ Graph::is_automorphism(const std::vector<unsigned int>& perm) const
 	  ei != v1.edges.end();
 	  ei++)
 	edges1.insert(perm[*ei]);
-      
+
       const Vertex& v2 = vertices[perm[i]];
       edges2.clear();
       for(std::vector<unsigned int>::const_iterator ei = v2.edges.begin();
@@ -5376,7 +5382,7 @@ Graph::nucr_find_first_component(const unsigned int level)
   /* The component is discrete, return false */
   if(!first_cell)
     return false;
-	
+
   std::vector<Partition::Cell*> component;
   first_cell->max_ival = 1;
   component.push_back(first_cell);
@@ -5384,13 +5390,13 @@ Graph::nucr_find_first_component(const unsigned int level)
   for(unsigned int i = 0; i < component.size(); i++)
     {
       Partition::Cell* const cell = component[i];
-	  
+
       const Vertex& v = vertices[p.elements[cell->first]];
       std::vector<unsigned int>::const_iterator ei = v.edges.begin();
       for(unsigned int j = v.nof_edges(); j > 0; j--)
 	{
 	  const unsigned int neighbour = *ei++;
-	  
+
 	  Partition::Cell* const neighbour_cell = p.get_cell(neighbour);
 
 	  /* Skip unit neighbours */
@@ -5412,13 +5418,13 @@ Graph::nucr_find_first_component(const unsigned int level)
 	  const unsigned int start = neighbour_heap.remove();
 	  Partition::Cell* const neighbour_cell =
 	    p.get_cell(p.elements[start]);
-	  
+
 	  /* Skip saturated neighbour cells */
 	  if(neighbour_cell->max_ival_count == neighbour_cell->length)
 	    {
 	      neighbour_cell->max_ival_count = 0;
 	      continue;
-	    } 
+	    }
 	  neighbour_cell->max_ival_count = 0;
 	  neighbour_cell->max_ival = 1;
 	  component.push_back(neighbour_cell);
@@ -5490,7 +5496,7 @@ Graph::nucr_find_first_component(const unsigned int level,
       for(unsigned int j = v.nof_edges(); j > 0; j--)
 	{
 	  const unsigned int neighbour = *ei++;
-	  
+
 	  Partition::Cell* const neighbour_cell = p.get_cell(neighbour);
 
 	  /* Skip unit neighbours */
@@ -5508,7 +5514,7 @@ Graph::nucr_find_first_component(const unsigned int level,
 	{
 	  Partition::Cell* const neighbour_cell = neighbours.pop();
 	  //neighbours.pop_back();
-	  
+
 	  /* Skip saturated neighbour cells */
 	  if(neighbour_cell->max_ival_count == neighbour_cell->length)
 	    {

--- a/src/heap.cc
+++ b/src/heap.cc
@@ -1,15 +1,19 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <limits.h>
+#ifdef _WIN32
+  #include <ciso646>
+#endif
+
 #include "bliss/defs.hh"
 #include "bliss/heap.hh"
 
 /*
   Copyright (c) 2003-2015 Tommi Junttila
   Released under the GNU Lesser General Public License version 3.
-  
+
   This file is part of bliss.
-  
+
   bliss is free software: you can redistribute it and/or modify
   it under the terms of the GNU Lesser General Public License as published by
   the Free Software Foundation, version 3 of the License.

--- a/src/partition.cc
+++ b/src/partition.cc
@@ -1,15 +1,19 @@
 #include <assert.h>
 #include <vector>
 #include <list>
+#ifdef _WIN32
+  #include <ciso646>
+#endif
+
 #include "bliss/graph.hh"
 #include "bliss/partition.hh"
 
 /*
   Copyright (c) 2003-2015 Tommi Junttila
   Released under the GNU Lesser General Public License version 3.
-  
+
   This file is part of bliss.
-  
+
   bliss is free software: you can redistribute it and/or modify
   it under the terms of the GNU Lesser General Public License as published by
   the Free Software Foundation, version 3 of the License.
@@ -169,14 +173,14 @@ Partition::goto_backtrack_point(BacktrackPoint p)
     cr_goto_backtrack_point(info.cr_backtrack_point);
 
   const unsigned int dest_refinement_stack_size = info.refinement_stack_size;
-  
+
   assert(refinement_stack.size() >= dest_refinement_stack_size);
   while(refinement_stack.size() > dest_refinement_stack_size)
     {
       RefInfo i = refinement_stack.pop();
       const unsigned int first = i.split_cell_first;
       Cell* cell = get_cell(elements[first]);
-      
+
       if(cell->first != first)
 	{
 	  assert(cell->first < first);
@@ -260,12 +264,12 @@ Partition::individualize(Partition::Cell * const cell,
   in_pos[*pos] = pos;
   elements[last] = element;
   in_pos[element] = elements + last;
-  
+
   Partition::Cell * const new_cell = aux_split_in_two(cell, cell->length-1);
   element_to_cell_map[element] = new_cell;
 
   return new_cell;
-} 
+}
 
 
 
@@ -336,7 +340,7 @@ Partition::aux_split_in_two(Partition::Cell* const cell,
     }
 
   return new_cell;
-} 
+}
 
 
 
@@ -394,7 +398,7 @@ Partition::splitting_queue_add(Cell* const cell)
   if(cell->length <= smallish_cell_threshold)
     splitting_queue.push_front(cell);
   else
-    splitting_queue.push_back(cell);    
+    splitting_queue.push_back(cell);
 }
 
 
@@ -627,7 +631,7 @@ Partition::sort_and_split_cell1(Partition::Cell* const cell)
  * dcs_start[0] = 0 and dcs_start[i+1] = dcs_start[i] + dcs_count[i].
  */
 void
-Partition::dcs_cumulate_count(const unsigned int max) 
+Partition::dcs_cumulate_count(const unsigned int max)
 {
   unsigned int* count_p = dcs_count;
   unsigned int* start_p = dcs_start;
@@ -656,7 +660,7 @@ Partition::sort_and_split_cell255(Partition::Cell* const cell,
       invariant_values[elements[cell->first]] = 0;
       return cell;
     }
-  
+
 #ifdef BLISS_CONSISTENCY_CHECKS
   for(unsigned int i = 0; i < 256; i++)
     assert(dcs_count[i] == 0);
@@ -808,7 +812,7 @@ Partition::split_cell(Partition::Cell* const original_cell)
     original_cell->in_splitting_queue;
   Cell* largest_new_cell = 0;
 
-  while(true) 
+  while(true)
     {
       unsigned int* ep = elements + cell->first;
       const unsigned int* const lp = ep + cell->length;
@@ -829,17 +833,17 @@ Partition::split_cell(Partition::Cell* const original_cell)
 	}
       if(ep == lp)
 	break;
-      
+
       Cell* const new_cell = aux_split_in_two(cell,
 					      (ep - elements) - cell->first);
-      
+
       if(graph and graph->compute_eqref_hash)
 	{
 	  graph->eqref_hash.update(new_cell->first);
 	  graph->eqref_hash.update(new_cell->length);
 	  graph->eqref_hash.update(ival);
 	}
-      
+
       /* Add cells in splitting_queue */
       assert(!new_cell->is_in_splitting_queue());
       if(original_cell_was_in_splitting_queue)
@@ -868,7 +872,7 @@ Partition::split_cell(Partition::Cell* const original_cell)
       cell = new_cell;
     }
 
-  
+
   if(original_cell == cell) {
     /* All the elements in cell had the same invariant value */
     return cell;


### PR DESCRIPTION
Making the cmake compatible with windows: mainly including "ciso646" on windows machines and removing the use of timer. 
Also bump the version to 0.73.3.
I attach the log that i got testing this on a windows machine in the commandline:

```
C:\Users\optimization\Downloads\bliss\Bliss-0.73.2>cmake --version
cmake version 3.17.0-rc2

CMake suite maintained and supported by Kitware (kitware.com/cmake).

C:\Users\optimization\Downloads\bliss\Bliss-0.73.2>cmake -H. -B"build" -G "Visual Studio 15 2017 Win64"
-- The CXX compiler identification is MSVC 19.11.25547.0
-- The C compiler identification is MSVC 19.11.25547.0
-- Check for working CXX compiler: C:/Program Files (x86)/Microsoft Visual Studio/2017/Community/VC/Tools/MSVC/14.11.25503/bin/Hostx86/x64/cl.exe
-- Check for working CXX compiler: C:/Program Files (x86)/Microsoft Visual Studio/2017/Community/VC/Tools/MSVC/14.11.25503/bin/Hostx86/x64/cl.exe - works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Check for working C compiler: C:/Program Files (x86)/Microsoft Visual Studio/2017/Community/VC/Tools/MSVC/14.11.25503/bin/Hostx86/x64/cl.exe
-- Check for working C compiler: C:/Program Files (x86)/Microsoft Visual Studio/2017/Community/VC/Tools/MSVC/14.11.25503/bin/Hostx86/x64/cl.exe - works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Detecting C compile features
-- Detecting C compile features - done
-- Configuring done
-- Generating done
-- Build files have been written to: C:/Users/optimization/Downloads/bliss/Bliss-0.73.2/build

C:\Users\optimization\Downloads\bliss\Bliss-0.73.2>cmake --build build --config Release
Microsoft (R)-Buildmodul, Version 15.4.8.50001 für .NET Framework
Copyright (C) Microsoft Corporation. Alle Rechte vorbehalten.

  Checking Build System
  Building Custom Rule C:/Users/optimization/Downloads/bliss/Bliss-0.73.2/CMakeLists.txt
  bliss_C.cc
C:\Users\optimization\Downloads\bliss\Bliss-0.73.2\include\bliss/graph.hh(607): warning C4267: 'return': conversion from 'size_t' to 'unsigned int', possible loss of data [C:\Users\optimization\Downloads\bliss\Bliss-0.73.2\build\libbliss.vcxproj]
C:\Users\optimization\Downloads\bliss\Bliss-0.73.2\include\bliss/graph.hh(735): warning C4267: 'return': conversion from 'size_t' to 'unsigned int', possible loss of data [C:\Users\optimization\Downloads\bliss\Bliss-0.73.2\build\libbliss.vcxproj]
C:\Users\optimization\Downloads\bliss\Bliss-0.73.2\include\bliss/graph.hh(837): warning C4267: 'return': conversion from 'size_t' to 'unsigned int', possible loss of data [C:\Users\optimization\Downloads\bliss\Bliss-0.73.2\build\libbliss.vcxproj]
C:\Users\optimization\Downloads\bliss\Bliss-0.73.2\include\bliss/graph.hh(838): warning C4267: 'return': conversion from 'size_t' to 'unsigned int', possible loss of data [C:\Users\optimization\Downloads\bliss\Bliss-0.73.2\build\libbliss.vcxproj]
C:\Users\optimization\Downloads\bliss\Bliss-0.73.2\include\bliss/graph.hh(974): warning C4267: 'return': conversion from 'size_t' to 'unsigned int', possible loss of data [C:\Users\optimization\Downloads\bliss\Bliss-0.73.2\build\libbliss.vcxproj]
  defs.cc
  graph.cc
C:\Users\optimization\Downloads\bliss\Bliss-0.73.2\include\bliss/graph.hh(607): warning C4267: 'return': conversion from 'size_t' to 'unsigned int', possible loss of data [C:\Users\optimization\Downloads\bliss\Bliss-0.73.2\build\libbliss.vcxproj]
C:\Users\optimization\Downloads\bliss\Bliss-0.73.2\include\bliss/graph.hh(735): warning C4267: 'return': conversion from 'size_t' to 'unsigned int', possible loss of data [C:\Users\optimization\Downloads\bliss\Bliss-0.73.2\build\libbliss.vcxproj]
C:\Users\optimization\Downloads\bliss\Bliss-0.73.2\include\bliss/graph.hh(837): warning C4267: 'return': conversion from 'size_t' to 'unsigned int', possible loss of data [C:\Users\optimization\Downloads\bliss\Bliss-0.73.2\build\libbliss.vcxproj]
C:\Users\optimization\Downloads\bliss\Bliss-0.73.2\include\bliss/graph.hh(838): warning C4267: 'return': conversion from 'size_t' to 'unsigned int', possible loss of data [C:\Users\optimization\Downloads\bliss\Bliss-0.73.2\build\libbliss.vcxproj]
C:\Users\optimization\Downloads\bliss\Bliss-0.73.2\include\bliss/graph.hh(974): warning C4267: 'return': conversion from 'size_t' to 'unsigned int', possible loss of data [C:\Users\optimization\Downloads\bliss\Bliss-0.73.2\build\libbliss.vcxproj]
C:\Users\optimization\Downloads\bliss\Bliss-0.73.2\src\graph.cc(319): warning C4267: 'initializing': conversion from 'size_t' to 'unsigned int', possible loss of data [C:\Users\optimization\Downloads\bliss\Bliss-0.73.2\build\libbliss.vcxproj]
C:\Users\optimization\Downloads\bliss\Bliss-0.73.2\src\graph.cc(353): warning C4267: 'initializing': conversion from 'size_t' to 'unsigned int', possible loss of data [C:\Users\optimization\Downloads\bliss\Bliss-0.73.2\build\libbliss.vcxproj]
C:\Users\optimization\Downloads\bliss\Bliss-0.73.2\src\graph.cc(792): warning C4267: '=': conversion from 'size_t' to 'unsigned int', possible loss of data [C:\Users\optimization\Downloads\bliss\Bliss-0.73.2\build\libbliss.vcxproj]
C:\Users\optimization\Downloads\bliss\Bliss-0.73.2\src\graph.cc(817): warning C4267: '=': conversion from 'size_t' to 'unsigned int', possible loss of data [C:\Users\optimization\Downloads\bliss\Bliss-0.73.2\build\libbliss.vcxproj]
C:\Users\optimization\Downloads\bliss\Bliss-0.73.2\src\graph.cc(1058): warning C4267: '=': conversion from 'size_t' to 'unsigned long', possible loss of data [C:\Users\optimization\Downloads\bliss\Bliss-0.73.2\build\libbliss.vcxproj]
C:\Users\optimization\Downloads\bliss\Bliss-0.73.2\src\graph.cc(1109): warning C4267: 'initializing': conversion from 'size_t' to 'unsigned int', possible loss of data [C:\Users\optimization\Downloads\bliss\Bliss-0.73.2\build\libbliss.vcxproj]
C:\Users\optimization\Downloads\bliss\Bliss-0.73.2\src\graph.cc(1109): warning C4267: 'initializing': conversion from 'size_t' to 'const unsigned int', possible loss of data [C:\Users\optimization\Downloads\bliss\Bliss-0.73.2\build\libbliss.vcxproj]
C:\Users\optimization\Downloads\bliss\Bliss-0.73.2\src\graph.cc(1234): warning C4267: '=': conversion from 'size_t' to 'unsigned int', possible loss of data [C:\Users\optimization\Downloads\bliss\Bliss-0.73.2\build\libbliss.vcxproj]
C:\Users\optimization\Downloads\bliss\Bliss-0.73.2\src\graph.cc(1277): warning C4267: 'initializing': conversion from 'size_t' to 'unsigned int', possible loss of data [C:\Users\optimization\Downloads\bliss\Bliss-0.73.2\build\libbliss.vcxproj]
C:\Users\optimization\Downloads\bliss\Bliss-0.73.2\src\graph.cc(1277): warning C4267: 'initializing': conversion from 'size_t' to 'const unsigned int', possible loss of data [C:\Users\optimization\Downloads\bliss\Bliss-0.73.2\build\libbliss.vcxproj]
C:\Users\optimization\Downloads\bliss\Bliss-0.73.2\src\graph.cc(1480): warning C4267: '=': conversion from 'size_t' to 'unsigned int', possible loss of data [C:\Users\optimization\Downloads\bliss\Bliss-0.73.2\build\libbliss.vcxproj]
C:\Users\optimization\Downloads\bliss\Bliss-0.73.2\src\graph.cc(1487): warning C4267: '=': conversion from 'size_t' to 'unsigned int', possible loss of data [C:\Users\optimization\Downloads\bliss\Bliss-0.73.2\build\libbliss.vcxproj]
C:\Users\optimization\Downloads\bliss\Bliss-0.73.2\src\graph.cc(1510): warning C4267: '=': conversion from 'size_t' to 'unsigned int', possible loss of data [C:\Users\optimization\Downloads\bliss\Bliss-0.73.2\build\libbliss.vcxproj]
C:\Users\optimization\Downloads\bliss\Bliss-0.73.2\src\graph.cc(1542): warning C4267: 'initializing': conversion from 'size_t' to 'unsigned int', possible loss of data [C:\Users\optimization\Downloads\bliss\Bliss-0.73.2\build\libbliss.vcxproj]
C:\Users\optimization\Downloads\bliss\Bliss-0.73.2\src\graph.cc(1542): warning C4267: 'initializing': conversion from 'size_t' to 'const unsigned int', possible loss of data [C:\Users\optimization\Downloads\bliss\Bliss-0.73.2\build\libbliss.vcxproj]
C:\Users\optimization\Downloads\bliss\Bliss-0.73.2\src\graph.cc(1604): warning C4267: 'initializing': conversion from 'size_t' to 'unsigned int', possible loss of data [C:\Users\optimization\Downloads\bliss\Bliss-0.73.2\build\libbliss.vcxproj]
C:\Users\optimization\Downloads\bliss\Bliss-0.73.2\src\graph.cc(1612): warning C4267: 'initializing': conversion from 'size_t' to 'unsigned int', possible loss of data [C:\Users\optimization\Downloads\bliss\Bliss-0.73.2\build\libbliss.vcxproj]
C:\Users\optimization\Downloads\bliss\Bliss-0.73.2\src\graph.cc(1938): warning C4267: 'initializing': conversion from 'size_t' to 'unsigned int', possible loss of data [C:\Users\optimization\Downloads\bliss\Bliss-0.73.2\build\libbliss.vcxproj]
C:\Users\optimization\Downloads\bliss\Bliss-0.73.2\src\graph.cc(1938): warning C4267: 'initializing': conversion from 'size_t' to 'const unsigned int', possible loss of data [C:\Users\optimization\Downloads\bliss\Bliss-0.73.2\build\libbliss.vcxproj]
C:\Users\optimization\Downloads\bliss\Bliss-0.73.2\src\graph.cc(2090): warning C4996: 'fopen': This function or variable may be unsafe. Consider using fopen_s instead. To disable deprecation, use _CRT_SECURE_NO_WARNINGS. See online help for details. [C:\Users\optimization\Downloads
\bliss\Bliss-0.73.2\build\libbliss.vcxproj]
  C:\Program Files (x86)\Windows Kits\10\Include\10.0.10240.0\ucrt\stdio.h(205): note: see declaration of 'fopen'
C:\Users\optimization\Downloads\bliss\Bliss-0.73.2\src\graph.cc(2225): warning C4996: 'fscanf': This function or variable may be unsafe. Consider using fscanf_s instead. To disable deprecation, use _CRT_SECURE_NO_WARNINGS. See online help for details. [C:\Users\optimization\Downloads\bliss\Bliss-0.73.2\build\libbliss.vcxproj]
  C:\Program Files (x86)\Windows Kits\10\Include\10.0.10240.0\ucrt\stdio.h(1193): note: see declaration of 'fscanf'
C:\Users\optimization\Downloads\bliss\Bliss-0.73.2\src\graph.cc(2274): warning C4996: 'fscanf': This function or variable may be unsafe. Consider using fscanf_s instead. To disable deprecation, use _CRT_SECURE_NO_WARNINGS. See online help for details. [C:\Users\optimization\Downloads\bliss\Bliss-0.73.2\build\libbliss.vcxproj]
  C:\Program Files (x86)\Windows Kits\10\Include\10.0.10240.0\ucrt\stdio.h(1193): note: see declaration of 'fscanf'
C:\Users\optimization\Downloads\bliss\Bliss-0.73.2\src\graph.cc(2309): warning C4996: 'fscanf': This function or variable may be unsafe. Consider using fscanf_s instead. To disable deprecation, use _CRT_SECURE_NO_WARNINGS. See online help for details. [C:\Users\optimization\Downloads\bliss\Bliss-0.73.2\build\libbliss.vcxproj]
  C:\Program Files (x86)\Windows Kits\10\Include\10.0.10240.0\ucrt\stdio.h(1193): note: see declaration of 'fscanf'
C:\Users\optimization\Downloads\bliss\Bliss-0.73.2\src\graph.cc(2363): warning C4267: '+=': conversion from 'size_t' to 'unsigned int', possible loss of data [C:\Users\optimization\Downloads\bliss\Bliss-0.73.2\build\libbliss.vcxproj]
C:\Users\optimization\Downloads\bliss\Bliss-0.73.2\src\graph.cc(4008): warning C4267: 'initializing': conversion from 'size_t' to 'unsigned int', possible loss of data [C:\Users\optimization\Downloads\bliss\Bliss-0.73.2\build\libbliss.vcxproj]
C:\Users\optimization\Downloads\bliss\Bliss-0.73.2\src\graph.cc(4008): warning C4267: 'initializing': conversion from 'size_t' to 'const unsigned int', possible loss of data [C:\Users\optimization\Downloads\bliss\Bliss-0.73.2\build\libbliss.vcxproj]
C:\Users\optimization\Downloads\bliss\Bliss-0.73.2\src\graph.cc(4077): warning C4996: 'fscanf': This function or variable may be unsafe. Consider using fscanf_s instead. To disable deprecation, use _CRT_SECURE_NO_WARNINGS. See online help for details. [C:\Users\optimization\Downloads\bliss\Bliss-0.73.2\build\libbliss.vcxproj]
  C:\Program Files (x86)\Windows Kits\10\Include\10.0.10240.0\ucrt\stdio.h(1193): note: see declaration of 'fscanf'
C:\Users\optimization\Downloads\bliss\Bliss-0.73.2\src\graph.cc(4126): warning C4996: 'fscanf': This function or variable may be unsafe. Consider using fscanf_s instead. To disable deprecation, use _CRT_SECURE_NO_WARNINGS. See online help for details. [C:\Users\optimization\Downloads\bliss\Bliss-0.73.2\build\libbliss.vcxproj]
  C:\Program Files (x86)\Windows Kits\10\Include\10.0.10240.0\ucrt\stdio.h(1193): note: see declaration of 'fscanf'
C:\Users\optimization\Downloads\bliss\Bliss-0.73.2\src\graph.cc(4161): warning C4996: 'fscanf': This function or variable may be unsafe. Consider using fscanf_s instead. To disable deprecation, use _CRT_SECURE_NO_WARNINGS. See online help for details. [C:\Users\optimization\Downloads\bliss\Bliss-0.73.2\build\libbliss.vcxproj]
  C:\Program Files (x86)\Windows Kits\10\Include\10.0.10240.0\ucrt\stdio.h(1193): note: see declaration of 'fscanf'
C:\Users\optimization\Downloads\bliss\Bliss-0.73.2\src\graph.cc(4380): warning C4996: 'fopen': This function or variable may be unsafe. Consider using fopen_s instead. To disable deprecation, use _CRT_SECURE_NO_WARNINGS. See online help for details. [C:\Users\optimization\Downloads\bliss\Bliss-0.73.2\build\libbliss.vcxproj]
  C:\Program Files (x86)\Windows Kits\10\Include\10.0.10240.0\ucrt\stdio.h(205): note: see declaration of 'fopen'
C:\Users\optimization\Downloads\bliss\Bliss-0.73.2\include\bliss/kqueue.hh(121): warning C4244: 'return': conversion from '__int64' to 'unsigned int', possible loss of data [C:\Users\optimization\Downloads\bliss\Bliss-0.73.2\build\libbliss.vcxproj]
  C:\Users\optimization\Downloads\bliss\Bliss-0.73.2\include\bliss/kqueue.hh(119): note: while compiling class template member function 'unsigned int bliss::KQueue<bliss::Partition::Cell *>::size(void) const'
  C:\Users\optimization\Downloads\bliss\Bliss-0.73.2\src\graph.cc(2671): note: see reference to function template instantiation 'unsigned intbliss::KQueue<bliss::Partition::Cell *>::size(void) const' being compiled
  C:\Users\optimization\Downloads\bliss\Bliss-0.73.2\include\bliss/partition.hh(114): note: see reference to class template instantiation 'bliss::KQueue<bliss::Partition::Cell *>' being compiled
C:\Users\optimization\Downloads\bliss\Bliss-0.73.2\include\bliss/kqueue.hh(122): warning C4244: 'return': conversion from '__int64' to 'unsigned int', possible loss of data [C:\Users\optimization\Downloads\bliss\Bliss-0.73.2\build\libbliss.vcxproj]
  heap.cc
  orbit.cc
  partition.cc
C:\Users\optimization\Downloads\bliss\Bliss-0.73.2\include\bliss/graph.hh(607): warning C4267: 'return': conversion from 'size_t' to 'unsigned int', possible loss of data [C:\Users\optimization\Downloads\bliss\Bliss-0.73.2\build\libbliss.vcxproj]
C:\Users\optimization\Downloads\bliss\Bliss-0.73.2\include\bliss/graph.hh(735): warning C4267: 'return': conversion from 'size_t' to 'unsigned int', possible loss of data [C:\Users\optimization\Downloads\bliss\Bliss-0.73.2\build\libbliss.vcxproj]
C:\Users\optimization\Downloads\bliss\Bliss-0.73.2\include\bliss/graph.hh(837): warning C4267: 'return': conversion from 'size_t' to 'unsigned int', possible loss of data [C:\Users\optimization\Downloads\bliss\Bliss-0.73.2\build\libbliss.vcxproj]
C:\Users\optimization\Downloads\bliss\Bliss-0.73.2\include\bliss/graph.hh(838): warning C4267: 'return': conversion from 'size_t' to 'unsigned int', possible loss of data [C:\Users\optimization\Downloads\bliss\Bliss-0.73.2\build\libbliss.vcxproj]
C:\Users\optimization\Downloads\bliss\Bliss-0.73.2\include\bliss/graph.hh(974): warning C4267: 'return': conversion from 'size_t' to 'unsigned int', possible loss of data [C:\Users\optimization\Downloads\bliss\Bliss-0.73.2\build\libbliss.vcxproj]
C:\Users\optimization\Downloads\bliss\Bliss-0.73.2\src\partition.cc(156): warning C4267: 'initializing': conversion from 'size_t' to 'bliss::Partition::BacktrackPoint', possible loss of data [C:\Users\optimization\Downloads\bliss\Bliss-0.73.2\build\libbliss.vcxproj]
C:\Users\optimization\Downloads\bliss\Bliss-0.73.2\src\partition.cc(835): warning C4244: 'argument': conversion from '__int64' to 'const unsigned int', possible loss of data [C:\Users\optimization\Downloads\bliss\Bliss-0.73.2\build\libbliss.vcxproj]
C:\Users\optimization\Downloads\bliss\Bliss-0.73.2\src\partition.cc(1069): warning C4267: '=': conversion from 'size_t' to 'unsigned int', possible loss of data [C:\Users\optimization\Downloads\bliss\Bliss-0.73.2\build\libbliss.vcxproj]
C:\Users\optimization\Downloads\bliss\Bliss-0.73.2\src\partition.cc(1070): warning C4267: '=': conversion from 'size_t' to 'unsigned int', possible loss of data [C:\Users\optimization\Downloads\bliss\Bliss-0.73.2\build\libbliss.vcxproj]
C:\Users\optimization\Downloads\bliss\Bliss-0.73.2\src\partition.cc(1072): warning C4267: 'return': conversion from 'size_t' to 'unsigned int', possible loss of data [C:\Users\optimization\Downloads\bliss\Bliss-0.73.2\build\libbliss.vcxproj]
C:\Users\optimization\Downloads\bliss\Bliss-0.73.2\src\partition.cc(1101): warning C4244: 'argument': conversion from '__int64' to 'const unsigned int', possible loss of data [C:\Users\optimization\Downloads\bliss\Bliss-0.73.2\build\libbliss.vcxproj]
C:\Users\optimization\Downloads\bliss\Bliss-0.73.2\include\bliss/kstack.hh(84): warning C4244: 'return': conversion from '__int64' to 'unsigned int', possible loss of data [C:\Users\optimization\Downloads\bliss\Bliss-0.73.2\build\libbliss.vcxproj]
  C:\Users\optimization\Downloads\bliss\Bliss-0.73.2\include\bliss/kstack.hh(84): note: while compiling class template member function 'unsigned int bliss::KStack<bliss::Partition::RefInfo>::size(void) const'
  int bliss::KStack<bliss::Partition::RefInfo>::size(void) const' being compiled
  C:\Users\optimization\Downloads\bliss\Bliss-0.73.2\include\bliss/partition.hh(97): note: see reference to class template instantiation 'bliss::KStack<bliss::Partition::RefInfo>' being compiled
  uintseqhash.cc
  utils.cc
C:\Users\optimization\Downloads\bliss\Bliss-0.73.2\src\utils.cc(65): warning C4267: 'initializing': conversion from 'size_t' to 'unsigned int', possible loss of data [C:\Users\optimization\Downloads\bliss\Bliss-0.73.2\build\libbliss.vcxproj]
C:\Users\optimization\Downloads\bliss\Bliss-0.73.2\src\utils.cc(65): warning C4267: 'initializing': conversion from 'size_t' to 'const unsigned int', possible loss of data [C:\Users\optimization\Downloads\bliss\Bliss-0.73.2\build\libbliss.vcxproj]
C:\Users\optimization\Downloads\bliss\Bliss-0.73.2\src\utils.cc(109): warning C4267: 'initializing': conversion from 'size_t' to 'unsigned int', possible loss of data [C:\Users\optimization\Downloads\bliss\Bliss-0.73.2\build\libbliss.vcxproj]
C:\Users\optimization\Downloads\bliss\Bliss-0.73.2\src\utils.cc(109): warning C4267: 'initializing': conversion from 'size_t' to 'const unsigned int', possible loss of data [C:\Users\optimization\Downloads\bliss\Bliss-0.73.2\build\libbliss.vcxproj]
  Generating Code...
  libbliss.vcxproj -> C:\Users\optimization\Downloads\bliss\Bliss-0.73.2\build\Release\bliss.lib
  Building Custom Rule C:/Users/optimization/Downloads/bliss/Bliss-0.73.2/CMakeLists.txt
  bliss.cc
C:\Users\optimization\Downloads\bliss\Bliss-0.73.2\include\bliss/graph.hh(607): warning C4267: 'return': conversion from 'size_t' to 'unsigned int', possible loss of data [C:\Users\optimization\Downloads\bliss\Bliss-0.73.2\build\bliss.vcxproj]
C:\Users\optimization\Downloads\bliss\Bliss-0.73.2\include\bliss/graph.hh(735): warning C4267: 'return': conversion from 'size_t' to 'unsigned int', possible loss of data [C:\Users\optimization\Downloads\bliss\Bliss-0.73.2\build\bliss.vcxproj]
C:\Users\optimization\Downloads\bliss\Bliss-0.73.2\include\bliss/graph.hh(837): warning C4267: 'return': conversion from 'size_t' to 'unsigned int', possible loss of data [C:\Users\optimization\Downloads\bliss\Bliss-0.73.2\build\bliss.vcxproj]
C:\Users\optimization\Downloads\bliss\Bliss-0.73.2\include\bliss/graph.hh(838): warning C4267: 'return': conversion from 'size_t' to 'unsigned int', possible loss of data [C:\Users\optimization\Downloads\bliss\Bliss-0.73.2\build\bliss.vcxproj]
C:\Users\optimization\Downloads\bliss\Bliss-0.73.2\include\bliss/graph.hh(974): warning C4267: 'return': conversion from 'size_t' to 'unsigned int', possible loss of data [C:\Users\optimization\Downloads\bliss\Bliss-0.73.2\build\bliss.vcxproj]
C:\Users\optimization\Downloads\bliss\Bliss-0.73.2\src\bliss.cc(106): warning C4996: 'sscanf': This function or variable may be unsafe. Consider using sscanf_s instead. To disable deprecation, use _CRT_SECURE_NO_WARNINGS. See online help for details. [C:\Users\optimization\Downloads\bliss\Bliss-0.73.2\build\bliss.vcxproj]
  C:\Program Files (x86)\Windows Kits\10\Include\10.0.10240.0\ucrt\stdio.h(2254): note: see declaration of 'sscanf'
C:\Users\optimization\Downloads\bliss\Bliss-0.73.2\src\bliss.cc(234): warning C4996: 'fopen': This function or variable may be unsafe. Consider using fopen_s instead. To disable deprecation, use _CRT_SECURE_NO_WARNINGS. See online help for details. [C:\Users\optimization\Downloads\bliss\Bliss-0.73.2\build\bliss.vcxproj]
  C:\Program Files (x86)\Windows Kits\10\Include\10.0.10240.0\ucrt\stdio.h(205): note: see declaration of 'fopen'
C:\Users\optimization\Downloads\bliss\Bliss-0.73.2\src\bliss.cc(292): warning C4996: 'fopen': This function or variable may be unsafe. Consider using fopen_s instead. To disable deprecation, use _CRT_SECURE_NO_WARNINGS. See online help for details. [C:\Users\optimization\Downloads\bliss\Bliss-0.73.2\build\bliss.vcxproj]
  C:\Program Files (x86)\Windows Kits\10\Include\10.0.10240.0\ucrt\stdio.h(205): note: see declaration of 'fopen'
  bliss.vcxproj -> C:\Users\optimization\Downloads\bliss\Bliss-0.73.2\build\Release\bliss.exe
  Building Custom Rule C:/Users/optimization/Downloads/bliss/Bliss-0.73.2/CMakeLists.txt

C:\Users\optimization\Downloads\bliss\Bliss-0.73.2>ls build\Release
bliss.exe  bliss.lib
```