### PR TITLE
add shared lib build to workflow; fix DLL build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,12 +8,13 @@ on:
 
 jobs:
   build:
-    name: ${{ matrix.runner }} - ${{ matrix.buildtype }} - ${{ github.event_name }}
+    name: ${{ matrix.runner }} - ${{ matrix.buildtype }} - shared${{ matrix.sharedlib }} - ${{ github.event_name }}
     runs-on: ${{ matrix.runner }}
     strategy:
       matrix:
         runner: [ubuntu-latest, ubuntu-24.04-arm, macos-15-intel, macos-latest, windows-latest, windows-11-arm]
         buildtype: [debug, release]
+        sharedlib: [on, off]
     steps:
       - uses: actions/checkout@v2
       - name: Create Build Environment
@@ -22,7 +23,7 @@ jobs:
       - name: Configure CMake
         shell: bash
         working-directory: ${{runner.workspace}}/build
-        run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=${{matrix.buildtype}}
+        run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=${{matrix.buildtype}} -DBUILD_SHARED_LIBS=${{matrix.sharedlib}}
 
       - name: Build
         working-directory: ${{runner.workspace}}/build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,6 +62,8 @@ set_target_properties(libbliss PROPERTIES
   # We cannot do this currently, because the code does not ensure that the API is made visible / exported
   #CXX_VISIBILITY_PRESET hidden
   #VISIBILITY_INLINES_HIDDEN ON
+  # But for Windows, we can ensure that all symbols are exported, which is anyway necessary when building a DLL
+  WINDOWS_EXPORT_ALL_SYMBOLS 1
 )
 
 add_executable(bliss src/bliss.cc)


### PR DESCRIPTION
Based on #3.

- adds sharedlib=on/off as additional dimension to matrix
- export all symbols on windows, so a usable DLL can be build
